### PR TITLE
generalize our users playbook across environments

### DIFF
--- a/playbooks/edx-west/users.yml
+++ b/playbooks/edx-west/users.yml
@@ -1,4 +1,4 @@
-- hosts: ~tag_Name_{{ machine }}_prod
+- hosts: ~tag_Name_{{ machine }}_{{ env }}
   sudo: True
   vars:
     secure_dir: '../../../edx-secret/ansible'


### PR DESCRIPTION
I frequently want to update all our users on a machine.  This dead-simple play will add or update users based on the "prod" list of users in our edx-secret repo.

To use, run with this option:

    -e "machine=jumpbox env=stage"

@jrbl or @stvstnfrd, when you get a sec