### PR TITLE
Upgrade Matplotlib's libfreetype dependency

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -562,6 +562,8 @@ edxapp_debian_pkgs:
   - libpng12-dev
   # Postgres support
   - libpq-dev
+  # https://groups.google.com/forum/#!topic/openedx-ops/qpsHXs4okHs
+  - libfreetype6-dev
 
 # Ruby Specific Vars
 edxapp_ruby_version: "1.9.3-p374"


### PR DESCRIPTION
This is prompted by a recent upstream change that updated Matplotlib.

https://groups.google.com/forum/#!topic/openedx-ops/qpsHXs4okHs
