### PR TITLE
Bring stage jumpbox config in line with prod

### DIFF
--- a/playbooks/edx-west/stage-jumpbox.yml
+++ b/playbooks/edx-west/stage-jumpbox.yml
@@ -8,19 +8,36 @@
     local_dir:  '../../../configuration-secure/ansible/local'
   roles:
     - common
-    - role: gh_users
-      gh_users:
-      - sefk
-      - jbau
-      - jrbl
-      - ali123
-      - caesar2164
-      - dcadams
-      - jinpa
-      - gbruhns
-      - stvstnfrd
-      - nparlante
-      - dylanrhodes
-      - caijim
-      - ataki
+    - supervisor
+    - role: user
+      user_info:
+        - name: jbau
+          github: true
+          type: admin
+        - name: jrbl
+          github: true
+          type: admin
+        - name: caesar2164
+          github: true
+          type: admin
+        - name: dcadams
+          github: true
+          type: admin
+        - name: nparlante
+          github: true
+        - name: stvstnfrd
+          github: true
+          type: admin
+        - name: jinpa
+          github: true
+        - name: gbruhns
+          github: true
+        - name: mondiaz
+          github: true
+        - name: dylanrhodes
+          github: true
+        - name: ataki
+          github: true
+        - name: caijim
+          github: true
       tags: users


### PR DESCRIPTION
@stvstnfrd This is how I give people access to jump stage; I make sure they're in this file, and I run:

```
ANSIBLE_CONFIG=stage-ansible.cfg ANSIBLE_EC2_INI=stage-ec2.ini ansible-playbook stage-jumpbox.yml -u ubuntu -c ssh -i ./ec2.py -t users
```

Once you've perused, please just go ahead and hit the button. :)
