### PR TITLE
Fix user creation role to work with inlined ssh keys

### DIFF
--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -131,7 +131,7 @@
 
 - name: copy additional authorized keys
   copy: >
-    content="{{ '\n'.join(item.authorized_keys) }}"
+    content="{{ item.authorized_keys }}"
     dest=/home/{{ item.name }}/.ssh/authorized_keys mode=0640
     owner={{ item.name }}
     mode=0440


### PR DESCRIPTION
* The default user creation role for users who haven't got keys on github was
  writing authorized_keys files with newlines between every character. That is
  clearly wrong.

@stvstnfrd @jbau 