### PR TITLE
Set default of false for DISPLAY_COURSE_TILES

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -663,6 +663,7 @@ lms_env_config:
     python_bin: '{% if EDXAPP_PYTHON_SANDBOX %}{{ edxapp_sandbox_venv_dir }}/bin/python{% endif %}'
     limits: "{{ EDXAPP_CODE_JAIL_LIMITS }}"
     user: '{{ edxapp_sandbox_user }}'
+  DISPLAY_COURSE_TILES: false
 cms_auth_config:
   <<: *edxapp_generic_auth
   SEGMENT_IO_KEY: "{{ EDXAPP_SEGMENT_IO_KEY }}"


### PR DESCRIPTION
Default setting of DISPLAY_COURSE_TILES

This was introduced to allow no tiles to be displayed on the SuClass home page.