### PR TITLE
Segregate machine-specific cache keys

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -823,10 +823,10 @@ generic_env_config:  &edxapp_generic_env
       TIMEOUT: 300
     staticfiles:
       <<: *default_generic_cache
-      KEY_PREFIX: "staticfiles:{{ env }}"
+      KEY_PREFIX: "staticfiles:{{ env }}:{{ ansible_hostname|default('') }}"
     configuration:
       <<: *default_generic_cache
-      KEY_PREFIX: "configuration:{{ env }}"
+      KEY_PREFIX: "configuration:{{ env }}:{{ ansible_hostname|default('') }}"
     celery:
       <<: *default_generic_cache
       KEY_PREFIX: "celery:{{ env }}"


### PR DESCRIPTION
This was causing issues where staticfiles caches to one machine would
affect others; i.e., deploying to privateprod would affect prod.