### PR TITLE
Reduce gunicorn worker count for LMS/CMS

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1168,7 +1168,7 @@ service_variants_enabled:
 
 #Number of gunicorn worker processes to spawn, as a multiplier to number of virtual cores
 worker_core_mult:
-  lms: 4
+  lms: 3
   cms: 2
 
 # Stanford-style Theming


### PR DESCRIPTION
We have been experiencing issues in production with memory (over-)utilization.
While we are restarting the gunicorn workers every `n` requests (see:
`EDXAPP_MAX_REQUESTS`), this seems insufficent.

TODO: write more here before merging.