### PR TITLE
Update default cache path to local/hidden

### DIFF
--- a/playbooks/ec2.ini
+++ b/playbooks/ec2.ini
@@ -47,7 +47,7 @@ route53 = False
 # will be written to this directory:
 #   - ansible-ec2.cache
 #   - ansible-ec2.index
-cache_path = /tmp
+cache_path = .cache
 
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.


### PR DESCRIPTION
We need this since multiple users may run this from the same machine,
*cough* _jenkins_ *cough*

We had been overriding this separately in the various ec2.ini's, but
this moves us closer to sharing configuration files.