### PR TITLE
Stop deploying notifier twice on sandboxes

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -35,7 +35,6 @@
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - { role: 'edxapp', celery_worker: True }
     - edxapp
-    - notifier
     - analytics_api
     - insights
     - edx_notes_api


### PR DESCRIPTION
The notifier role was first added to this play in in December 2014 [1].
This PR was primarily notifier-related.
See: [3]

This role was again added, this time without a configured interval, in
February of 2015 [2]. This role was added alongside several others.
Perhaps the duplication was overlooked at the time?
See: [4]

[1] https://github.com/edx/configuration/commit/83053b52863e230d38ee0c2c2b2a71601725fe90
[2] https://github.com/edx/configuration/commit/cef9193ddf7b5c450be44d55e4ffd620a9e73392
[3] https://github.com/edx/configuration/blob/141ef9d2fd3c4788b04309e55c15f9de03adb030/playbooks/edx_sandbox.yml#L59
[4] https://github.com/edx/configuration/blob/141ef9d2fd3c4788b04309e55c15f9de03adb030/playbooks/edx_sandbox.yml#L49