### PR TITLE
Enable ansible lookups with route53 names

### DIFF
--- a/playbooks/ec2.ini
+++ b/playbooks/ec2.ini
@@ -36,7 +36,7 @@ vpc_destination_variable = private_ip_address
 
 # To tag instances on EC2 with the resource records that point to them from
 # Route53, uncomment and set 'route53' to True.
-route53 = False
+route53 = True
 
 # Additionally, you can specify the list of zones to exclude looking up in
 # 'route53_excluded_zones' as a comma-seperated list.


### PR DESCRIPTION
This is pulled from the mega branch.
