### PR TITLE
Define missing certs variable

### DIFF
--- a/playbooks/roles/certs/defaults/main.yml
+++ b/playbooks/roles/certs/defaults/main.yml
@@ -38,6 +38,7 @@ CERTS_LOCAL_PRIVATE_KEY: "example-private-key.txt"
 CERTS_REPO: "https://github.com/Stanford-Online/openedx-certificates.git"
 CERTS_NGINX_PORT: 18090
 CERTS_WEB_ROOT: "{{ certs_data_dir }}/www-data"
+CERTS_TMP_DIR: '/tmp/tmp_cert-'
 CERTS_URL: "http://localhost:{{ CERTS_NGINX_PORT }}"
 CERTS_DOWNLOAD_URL: "http://localhost:{{ CERTS_NGINX_PORT }}"
 CERTS_VERIFY_URL: "http://localhost:{{ CERTS_NGINX_PORT }}"


### PR DESCRIPTION
@caesar2164 There was no default specified here in `configuration`, so this failed on sandboxes/devstacks. For whatever reason, we were setting this in secrets..