### PR TITLE
Fix minor configuration errors in ELK stack

### DIFF
--- a/playbooks/roles/logstash/templates/logstash.conf.j2
+++ b/playbooks/roles/logstash/templates/logstash.conf.j2
@@ -132,7 +132,7 @@ output {
   }
   # And gzip for each host and program
   file {
-       path => '{{ logstash_data_dir }}/%{@source_host}/all.%{+yyyyMMdd}.gz'
+       path => '{{ logstash_external_log_dir }}/%{@source_host}/all.%{+yyyyMMdd}.gz'
        gzip => true
   }
   # Should add option for S3 as well.

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -9,6 +9,7 @@ nginx_extra_configs: []
 NGINX_EDXAPP_EXTRA_SITES: []
 NGINX_EDXAPP_EXTRA_CONFIGS: []
 NGINX_EDXAPP_CUSTOM_REDIRECTS: {}
+NGINX_ELASTICSEARCH_HOST: localhost
 
 NGINX_ENABLE_SSL: False
 # Set these to real paths on your

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
@@ -5,7 +5,7 @@
 {%- endif -%}
 
 upstream elasticsearch_server {
-		 server 127.0.0.1:9200;
+		 server "{{ NGINX_ELASTICSEARCH_HOST }}:9200";
 }
 
 server {

--- a/stanford/logs-frontend.yml
+++ b/stanford/logs-frontend.yml
@@ -7,8 +7,11 @@
     KIBANA_NGINX_PORT: 80
     KIBANA_SSL_NGINX_PORT: 443
     KIBANA_ELASTICSEARCH_HOST: localhost
+    NGINX_ELASTICSEARCH_HOST: localhost
   roles:
     - common
     - oraclejdk
-    - nginx
+    - role: nginx
+      nginx_sites:
+        - kibana
     - kibana


### PR DESCRIPTION
- Make the host nginx believes elasticsearch lives on to be configurable
- Change a variable name to the clearer version in logstash config
- Make sure frontend nginx adds kibana as an enabled site