### PR TITLE
Write GPG-trust with template

### DIFF
--- a/playbooks/roles/certs/defaults/main.yml
+++ b/playbooks/roles/certs/defaults/main.yml
@@ -52,7 +52,7 @@ CERTS_S3_UPLOAD: false
 CERTS_TEMPLATE_DATA_DIR: 'template_data'
 # this is the trust export, output of
 # gpg --export-ownertrust
-CERTS_OWNER_TRUST: "A9F9EAD11A0A6E7E5A037BDC044089B6FEF8D954:6:\n"
+CERTS_OWNER_TRUST: 'A9F9EAD11A0A6E7E5A037BDC044089B6FEF8D954:6:'
 
 # If no organization can be found, use this as the certifying organization
 CERTS_DEFAULT_ORG: "Default Organization"

--- a/playbooks/roles/certs/tasks/main.yml
+++ b/playbooks/roles/certs/tasks/main.yml
@@ -88,8 +88,8 @@
   register: certs_gpg_key
 
 - name: copy the pgp trust export
-  copy: >
-    content={{ CERTS_OWNER_TRUST }}
+  template: >
+    src=gpg-trust.j2
     dest={{ certs_app_dir }}/trust.export
     owner={{ common_web_user }}
     mode=0600

--- a/playbooks/roles/certs/templates/gpg-trust.j2
+++ b/playbooks/roles/certs/templates/gpg-trust.j2
@@ -1,0 +1,1 @@
+{{ CERTS_OWNER_TRUST }}


### PR DESCRIPTION
instead of manually writing a variable out to file.

The newline was no longer rendering properly. This may be related to a
previous Ansible upgrade; maybe it's been broken longer.
I only noticed when creating new devstacks/sandboxes; this task isn't
run on machines where the file already existed.