### PR TITLE
Install cert templates only when defined

### DIFF
--- a/playbooks/roles/certs/defaults/main.yml
+++ b/playbooks/roles/certs/defaults/main.yml
@@ -80,6 +80,7 @@ certs_git_identity: "{{ certs_app_dir }}/certs-git-identity"
 certs_requirements_file: "{{ certs_code_dir }}/requirements.txt"
 certs_version: 'rc'
 certs_templates_version : 'rc'
+certs_templates_repo: ''  # Set this to a private git repository of certificate templates
 certs_gpg_dir: "{{ certs_app_dir }}/gnupg"
 certs_template_dir: "{{ certs_app_dir }}/templates"
 certs_env_config:

--- a/playbooks/roles/certs/tasks/deploy.yml
+++ b/playbooks/roles/certs/tasks/deploy.yml
@@ -20,6 +20,7 @@
 
 - name: install read-only certs ssh key
   copy: src="{{ secure_dir }}/files/git-identity-certs" dest="{{ certs_git_identity }}" owner={{ certs_user }} mode=0600
+  when: "{{ certs_templates_repo | bool }}"
 
 - name: checkout local theme
   git: >
@@ -31,6 +32,7 @@
     GIT_SSH: "{{ certs_git_ssh }}"
   notify:
   - "restart certs"
+  when: "{{ certs_templates_repo | bool }}"
 
 - name: writing supervisor script for certificates
   template: >


### PR DESCRIPTION
We don't always have this set for sandboxes/devstacks.