### PR TITLE
Install Stanford's Analytics API explicitly

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -75,7 +75,7 @@ ANALYTICS_API_SERVICE_CONFIG:
 ANALYTICS_API_REPOS:
   - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
     DOMAIN: "{{ COMMON_GIT_MIRROR }}"
-    PATH: "{{ COMMON_GIT_PATH }}"
+    PATH: 'Stanford-Online'
     REPO: edx-analytics-data-api.git
     VERSION: "{{ ANALYTICS_API_VERSION }}"
     DESTINATION: "{{ analytics_api_code_dir }}"


### PR DESCRIPTION
There are some cases, like sandboxes and devstacks, where this isn't set
properly. We can't set COMMON_GIT_PATH universally because there are
some repositories that we still need from edx.