### PR TITLE
Variable defaults for elasticsearch role

### DIFF
--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -15,3 +15,7 @@ elasticsearch_group: "elasticsearch"
 ELASTICSEARCH_CLUSTER_MEMBERS: []
 ELASTICSEARCH_HEAP_SIZE: "512m"
 ELASTICSEARCH_VERSION: "0.90.13"
+
+# Defaults for the elk stack
+Deployment: "default"
+Cluster: "default"


### PR DESCRIPTION
Adding some defaults so that the configuration template renders in devstack mode