### PR TITLE
Remove Cluster/Deployment dependency from roles

### DIFF
--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -13,5 +13,6 @@ elasticsearch_group: "elasticsearch"
 #
 # Defaults for a single server installation.
 ELASTICSEARCH_CLUSTER_MEMBERS: []
+ELASTICSEARCH_CLUSTER_NAME: 'localhost'
 ELASTICSEARCH_HEAP_SIZE: "512m"
 ELASTICSEARCH_VERSION: "0.90.13"

--- a/playbooks/roles/elasticsearch/templates/edx/etc/elasticsearch/elasticsearch.yml.j2
+++ b/playbooks/roles/elasticsearch/templates/edx/etc/elasticsearch/elasticsearch.yml.j2
@@ -21,7 +21,7 @@ bootstrap.mlockall: true
 # CVE: CVE-2014-3120
 script.disable_dynamic: true
 
-cluster.name: "{{ Deployment }}-{{ Cluster }}"
+cluster.name: "{{ ELASTICSEARCH_CLUSTER_NAME }}"
 
 # Unicast discovery allows to explicitly control which nodes will be used
 # to discover the cluster. It can be used when multicast is not present,

--- a/stanford/elasticsearch.yml
+++ b/stanford/elasticsearch.yml
@@ -33,6 +33,7 @@
   gather_facts: True
   vars:
     ELASTICSEARCH_HEAP_SIZE: "{{ (ansible_memtotal_mb / 2) | int }}m"
+    ELASTICSEARCH_CLUSTER_NAME: "{{ Deployment }}-{{ Cluster }}"
     Number: 1
     Cluster: elasticsearch-elk
     Deployment: "{{ Deployment }}"


### PR DESCRIPTION
Let's hide this abstraction from the public/shared roles, and instead
isolate the Cluster/Deployment logic within our own plays.

This replaces https://github.com/Stanford-Online/configuration/pull/137