### PR TITLE
Use aws config when running migrations

### DIFF
--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -109,7 +109,6 @@
   environment:
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
     DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
-    EDX_PLATFORM_SETTINGS_OVERRIDE: "aws_migrate"
   with_items: service_variants_enabled
 
 # Gather assets using paver if possible


### PR DESCRIPTION
Otherwise, SECRET_KEY is undefined and things fall apart (required in dj18).

This was extracted from an upstream commit [1][2].

[1] 924a7a01ba2ad4322b4ca5dd08431d3fff00f4f2
[2] https://github.com/edx/configuration/commit/924a7a01ba2ad4322b4ca5dd08431d3fff00f4f2#diff-295d2728f4e59240e89172aca35bfd3c