### PR TITLE
Bootstrap new instances with Python2

### DIFF
--- a/stanford/playbooks/cluster.yml
+++ b/stanford/playbooks/cluster.yml
@@ -7,3 +7,9 @@
     - "{{ secure_dir }}/vars/{{ COMMON_DEPLOYMENT }}/{{ CLUSTER_NAME }}.yml"
   roles:
     - cluster
+- name: Bootstrap instance(s)
+  hosts: cluster_group_launched
+  gather_facts: no
+  become: True
+  roles:
+    - python


### PR DESCRIPTION
since Ubuntu 16.04 (xenial) only comes with Python3, by default.