### PR TITLE
Tag load balancers on creation

### DIFF
--- a/stanford/roles/cluster/tasks/main.yml
+++ b/stanford/roles/cluster/tasks/main.yml
@@ -14,11 +14,10 @@
     listeners: "{{ item.listeners }}"
     health_check: "{{ item.health_check }}"
     region: "{{ region }}"
-    # the `tags` keyword is not supported until Ansible 2.1
-    # tags:
-    #   Cluster: "{ CLUSTER_NAME }}"
-    #   Deployment: "{ COMMON_DEPLOYMENT }}"
-    #   Name: "{{ COMMON_DEPLOYMENT }}-elb-{{ CLUSTER_NAME }}"
+    tags:
+      Cluster: "{{ CLUSTER_NAME }}"
+      Deployment: "{{ COMMON_DEPLOYMENT }}"
+      Name: "{{ COMMON_DEPLOYMENT }}-elb-{{ CLUSTER_NAME }}"
   with_items: "{{ CLUSTER_ELBS }}"
   register: cluster_elb
 - debug: var=cluster_elb


### PR DESCRIPTION
This is now supported with Ansible 2.1+;
we're running 2.2.