### PR TITLE
Use cross-platform `date` syntax

### DIFF
--- a/stanford/roles/cluster/tasks/main.yml
+++ b/stanford/roles/cluster/tasks/main.yml
@@ -31,7 +31,7 @@
     count: 1
     vpc_subnet_id: "{{ CLUSTER_SUBNET_ID }}"
     instance_tags:
-      Birthday: "{{ lookup('pipe', 'date -u --rfc-3339=seconds') }}"
+      Birthday: "{{ lookup('pipe', \"date -u +'%Y-%m-%d %H:%M:%S'\") }}"
       Cluster: "{{ CLUSTER_NAME }}"
       Deployment: "{{ COMMON_DEPLOYMENT }}"
       Name: "{{ COMMON_DEPLOYMENT }}-box-{{ CLUSTER_NAME }}-{{ CLUSTER_NUMBER }}"


### PR DESCRIPTION
The former syntax did not work on OSX.