### PR TITLE
Remove /register redirect which causes TPA to endlessly loop

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/shib-only.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/shib-only.j2
@@ -1,8 +1,4 @@
 {%- if EDXAPP_SHIB_ONLY -%}
-  location /register {
-    return 302 /auth/login/tpa-saml/?auth_entry=register&idp=sunet&$args;
-  }
-
   location ~ ^/login$ {
     return 302 /auth/login/tpa-saml/?auth_entry=login&idp=sunet&$args;
   }


### PR DESCRIPTION
@caesar2164 @stvstnfrd 

This fix doesn't address the fact that intrepid users can go to /register and make a suclass account without going through TPA