### PR TITLE
Stop purging unspecified routes

### DIFF
--- a/stanford/roles/cluster/tasks/main.yml
+++ b/stanford/roles/cluster/tasks/main.yml
@@ -19,6 +19,7 @@
   ec2_vpc_route_table:
     vpc_id: "{{ DEPLOYMENT_VPC_ID }}"
     region: "{{ DEPLOYMENT_REGION }}"
+    purge_routes: false
     purge_subnets: false
     routes:
       - dest: 0.0.0.0/0
@@ -40,6 +41,7 @@
   ec2_vpc_route_table:
     vpc_id: "{{ DEPLOYMENT_VPC_ID }}"
     region: "{{ DEPLOYMENT_REGION }}"
+    purge_routes: false
     purge_subnets: false
     subnets:
       - "{{ CLUSTER_SUBNET_ID }}"

--- a/stanford/roles/deployment/tasks/main.yml
+++ b/stanford/roles/deployment/tasks/main.yml
@@ -45,6 +45,7 @@
   ec2_vpc_route_table:
     vpc_id: "{{ DEPLOYMENT_VPC_ID }}"
     region: "{{ DEPLOYMENT_REGION }}"
+    purge_routes: false
     purge_subnets: false
     subnets:
       - "{{ deployment_subnet_nat.subnet.id }}"


### PR DESCRIPTION
when updating the route tables.

References:
- [1] http://docs.ansible.com/ansible/latest/ec2_vpc_route_table_module.html