### PR TITLE
Remove lms nginx redirects for suclass TPA

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/shib-only.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/shib-only.j2
@@ -1,12 +1,4 @@
 {%- if EDXAPP_SHIB_ONLY -%}
-  location ~ ^/login$ {
-    return 302 /auth/login/tpa-saml/?auth_entry=login&idp=sunet&$args;
-  }
-
-  location /accounts/login {
-    return 302 /auth/login/tpa-saml/?auth_entry=login&idp=sunet&$args;
-  }
-
   location /signup {
     return 302 $scheme://{{ EDXAPP_LMS_SITE_NAME }}/auth/login/tpa-saml/?auth_entry=register&idp=sunet&next=/cms;
   }


### PR DESCRIPTION
Redirect is now handled in Django via FORCED_TPA_PROVIDER_ID setting

@stvstnfrd @caesar2164 