### PR TITLE
Remove custom jenkins plugin

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -89,11 +89,7 @@ jenkins_bundled_plugins:
     - "ssh-credentials"
     - "ssh-slaves"
 
-jenkins_custom_plugins:
-    - { repo_name: "github-sqs-plugin",
-        repo_url: "https://github.com/jzoldak/github-sqs-plugin.git",
-        package: "github-sqs-plugin.hpi",
-        version: "a6069caf072f13178c0c83b3b95f4d6ae12caad0" }
+jenkins_custom_plugins: []
 
 jenkins_debian_pkgs:
     - nginx


### PR DESCRIPTION
since it now longer exists.
There is an upstream PR for this change, but it includes unrelated
changes that we don't want/need now.