### PR TITLE
Rename cluster role variable

### DIFF
--- a/stanford/roles/cluster/tasks/main.yml
+++ b/stanford/roles/cluster/tasks/main.yml
@@ -56,9 +56,9 @@
       Network: Public
       Name: "{{ COMMON_DEPLOYMENT }}-route-public-{{ DEPLOYMENT_NUMBER }}"
       Number: "{{ DEPLOYMENT_NUMBER }}"
-  register: deployment_route_public
+  register: cluster_route_public
   when: CLUSTER_NETWORK == 'public'
-- debug: var=deployment_route_public
+- debug: var=cluster_route_public
   when: CLUSTER_NETWORK == 'public'
 
 - debug: var=CLUSTER_ELBS[CLUSTER_NAME]


### PR DESCRIPTION
In what was presumably a copy/paste relic, the `cluster` role mistakenly
used the `deployment` role's variable name prefix, overwriting the
latter's variable.

This hadn't caused any issues to date, though it possibly could down the
line; each role should only update its own variables.