### PR TITLE
Make deployment resource creation optional

### DIFF
--- a/stanford/roles/cluster/tasks/main.yml
+++ b/stanford/roles/cluster/tasks/main.yml
@@ -48,7 +48,7 @@
       - "{{ CLUSTER_SUBNET_ID }}"
     routes:
       - dest: 0.0.0.0/0
-        gateway_id: "{{ deployment_gateway.gateway_id }}"
+        gateway_id: "{{ DEPLOYMENT_INTERNET_GATEWAY_ID }}"
       - dest: "{{ DEPLOYMENT_CIDR }}"
         gateway_id: local
     tags:

--- a/stanford/roles/deployment/defaults/main.yml
+++ b/stanford/roles/deployment/defaults/main.yml
@@ -8,7 +8,6 @@ DEPLOYMENT_SSL_CERTIFICATE_ID: 'arn:aws:acm:<REGION>:<ACCOUNT>:certificate/<GUID
 deployment_subnet_index: "{{ (CLUSTER_NUMBER - 1 |int|abs) % 2 |int }}"
 DEPLOYMENT_NUMBER: "{{ deployment_subnet_index|int + 1 | int }}"
 DEPLOYMENT_SUBNET_PUBLIC: "{{ DEPLOYMENT_SUBNETS['public'][deployment_subnet_index|int] }}"
-DEPLOYMENT_SUBNET_PUBLIC_ID: "{{ deployment_subnet_public.subnet.id }}"
 DEPLOYMENT_SUBNET_PUBLIC_NAME: "{{ COMMON_DEPLOYMENT }}-subnet-public-{{ DEPLOYMENT_NUMBER }}"
 DEPLOYMENT_SUBNETS:
   public:

--- a/stanford/roles/deployment/tasks/main.yml
+++ b/stanford/roles/deployment/tasks/main.yml
@@ -45,6 +45,15 @@
       Name: "{{ DEPLOYMENT_SUBNET_PUBLIC_NAME }}"
       Number: "{{ DEPLOYMENT_NUMBER }}"
   register: deployment_subnet_public
+  when: DEPLOYMENT_SUBNET_PUBLIC_IDS is not defined
+- name: Set public subnet facts
+  set_fact:
+    DEPLOYMENT_SUBNET_PUBLIC_ID: "{{ deployment_subnet_public.subnet.id }}"
+  when: DEPLOYMENT_SUBNET_PUBLIC_IDS is not defined
+- name: Set public subnet facts
+  set_fact:
+    DEPLOYMENT_SUBNET_PUBLIC_ID: "{{ DEPLOYMENT_SUBNET_PUBLIC_IDS[deployment_subnet_index|int] }}"
+  when: DEPLOYMENT_SUBNET_PUBLIC_IDS is defined
 - debug: var=deployment_subnet_public
 
 - name: Create public route table

--- a/stanford/roles/deployment/tasks/main.yml
+++ b/stanford/roles/deployment/tasks/main.yml
@@ -16,6 +16,7 @@
     DEPLOYMENT_VPC_ID: "{{ deployment_vpc.vpc.id }}"
   when: DEPLOYMENT_VPC_ID is not defined
 - debug: var=DEPLOYMENT_VPC_ID
+
 - name: Create internet gateway
   ec2_vpc_igw:
     vpc_id: "{{ DEPLOYMENT_VPC_ID }}"
@@ -32,6 +33,7 @@
   set_fact:
     DEPLOYMENT_INTERNET_GATEWAY_ID: "{{ deployment_gateway.gateway_id }}"
   when: DEPLOYMENT_INTERNET_GATEWAY_ID is not defined
+- debug: var=DEPLOYMENT_INTERNET_GATEWAY_ID
 
 - name: Create public subnet
   ec2_vpc_subnet:
@@ -46,6 +48,7 @@
       Number: "{{ DEPLOYMENT_NUMBER }}"
   register: deployment_subnet_public
   when: DEPLOYMENT_SUBNET_PUBLIC_IDS is not defined
+- debug: var=deployment_subnet_public
 - name: Set public subnet facts
   set_fact:
     DEPLOYMENT_SUBNET_PUBLIC_ID: "{{ deployment_subnet_public.subnet.id }}"
@@ -54,7 +57,7 @@
   set_fact:
     DEPLOYMENT_SUBNET_PUBLIC_ID: "{{ DEPLOYMENT_SUBNET_PUBLIC_IDS[deployment_subnet_index|int] }}"
   when: DEPLOYMENT_SUBNET_PUBLIC_IDS is defined
-- debug: var=deployment_subnet_public
+- debug: var=DEPLOYMENT_SUBNET_PUBLIC_ID
 
 - name: Create public route table
   ec2_vpc_route_table:

--- a/stanford/roles/deployment/tasks/main.yml
+++ b/stanford/roles/deployment/tasks/main.yml
@@ -75,6 +75,7 @@
       Name: "{{ COMMON_DEPLOYMENT }}-route-public-{{ DEPLOYMENT_NUMBER }}"
       Number: "{{ DEPLOYMENT_NUMBER }}"
   register: deployment_route_public
+  when: DEPLOYMENT_SUBNET_PUBLIC_IDS is not defined
 - debug: var=deployment_route_public
 
 - name: Create NAT gateway

--- a/stanford/roles/deployment/tasks/main.yml
+++ b/stanford/roles/deployment/tasks/main.yml
@@ -21,11 +21,17 @@
     vpc_id: "{{ DEPLOYMENT_VPC_ID }}"
     state: present
   register: deployment_gateway
+  when: DEPLOYMENT_INTERNET_GATEWAY_ID is not defined
   # Not supported until Ansible 2.4
   # tags:
   #   Deployment: "{{ COMMON_DEPLOYMENT }}"
   #   Name: "{{ COMMON_DEPLOYMENT }}-gateway-internet"
 - debug: var=deployment_gateway
+  when: DEPLOYMENT_INTERNET_GATEWAY_ID is not defined
+- name: Set internet gateway facts
+  set_fact:
+    DEPLOYMENT_INTERNET_GATEWAY_ID: "{{ deployment_gateway.gateway_id }}"
+  when: DEPLOYMENT_INTERNET_GATEWAY_ID is not defined
 
 - name: Create public subnet
   ec2_vpc_subnet:
@@ -51,7 +57,7 @@
       - "{{ DEPLOYMENT_SUBNET_PUBLIC_ID }}"
     routes:
       - dest: 0.0.0.0/0
-        gateway_id: "{{ deployment_gateway.gateway_id }}"
+        gateway_id: "{{ DEPLOYMENT_INTERNET_GATEWAY_ID }}"
       - dest: "{{ DEPLOYMENT_CIDR }}"
         gateway_id: local
     tags:


### PR DESCRIPTION
We were doing this already for the VPC (via `VPC_ID`), as well as the
NAT gateway (via  the `if_exist_do_not_create` flag), but this now
extends the behavior to all of the other resources too.

This now covers:
- internet gateway
- public subnet
- public route table

There's no need to touch these any more often than necessary and I still
worry about accidentally breaking (or even inadvertently modifying)
existing resources when provisioning new clusters.