### PR TITLE
Omit successfull `/heartbeat` requests from logs

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -10,6 +10,8 @@ upstream cms-backend {
     {% endfor %}
 }
 
+{% include "loggable.j2" %}
+
 server {
   # CMS configuration file for nginx, templated by ansible
       
@@ -73,7 +75,7 @@ error_page {{ k }} {{ v }};
 
   server_name {{ CMS_HOSTNAME }};
 
-  access_log {{ nginx_log_dir }}/cms_access.log {{ NGINX_LOG_FORMAT_NAME }};
+  access_log {{ nginx_log_dir }}/cms_access.log {{ NGINX_LOG_FORMAT_NAME }} if=$loggable;
   error_log {{ nginx_log_dir }}/cms_error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots. 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -45,6 +45,8 @@ geo $http_x_forwarded_for $embargo {
 }
 {%- endif %}
 
+{% include "loggable.j2" %}
+
 server {
   # LMS configuration file for nginx, templated by ansible
 
@@ -112,7 +114,7 @@ error_page {{ k }} {{ v }};
   }
   {% endif %}
   
-  access_log {{ nginx_log_dir }}/lms_access.log {{ NGINX_LOG_FORMAT_NAME }};
+  access_log {{ nginx_log_dir }}/lms_access.log {{ NGINX_LOG_FORMAT_NAME }} if=$loggable;
   error_log {{ nginx_log_dir }}/lms_error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/loggable.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/loggable.j2
@@ -1,0 +1,4 @@
+map $request_uri $loggable {
+  /heartbeat 0;
+  default 1;
+}


### PR DESCRIPTION
This has long been a frustration of mine.
It's a pain to be `tail`ing logs and have the screen fill up with
heartbeat checks every few seconds.

I was prompted to revisit this following the recent issue with log files
taking up a significant amount of disk space.

Note: only successful attempts are excluded from the logs.
Should an error occur, it will still be logged to the error log file.