### PR TITLE
Force stage to be a single-AZ deployment

### DIFF
--- a/stanford/stage/group_vars/all
+++ b/stanford/stage/group_vars/all
@@ -1,5 +1,6 @@
 ---
 ansible_jumpbox: jump1.stage.lagunita.stanford.edu
+deployment_subnet_index: 0
 secure_dir: ../../../etc/ansible
 region: us-west-1
 


### PR DESCRIPTION
Since stage is just used for testing, we're not concerned with HA
(High Availability). By explicitly pinning the `deployment_subnet_index`
to zero, we can ensure that only a single subnet will be created per
cluster.