### PR TITLE
Replace sudo inside playbooks

### DIFF
--- a/stanford/playbooks/beats.yml
+++ b/stanford/playbooks/beats.yml
@@ -1,6 +1,6 @@
 - name: Configure instance(s)
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     FILEBEAT_LOGSTASH_HOST: "logstash.{{ Deployment }}.vpc"

--- a/stanford/playbooks/db-grader-proxy.yml
+++ b/stanford/playbooks/db-grader-proxy.yml
@@ -1,5 +1,5 @@
 - hosts: tag_environment_prod:&tag_function_dbgrader
-  sudo: True
+  become: True
   vars_files:
     - "{{ COMMON_DEPLOYMENT_DIR }}/db-grader.yml"
   roles:

--- a/stanford/playbooks/elasticsearch_elk.yml
+++ b/stanford/playbooks/elasticsearch_elk.yml
@@ -29,7 +29,7 @@
       healthy_threshold: 10
 - name: Configure elasticsearach
   hosts: launched
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     ELASTICSEARCH_HEAP_SIZE: "{{ (ansible_memtotal_mb / 2) | int }}m"

--- a/stanford/playbooks/insights-api.yml
+++ b/stanford/playbooks/insights-api.yml
@@ -1,5 +1,5 @@
 - hosts: ~tag_Name_{{ machine }}_{{ env }}
-  sudo: True
+  become: True
   gather_facts: True
   vars_files:
     - "{{ COMMON_DEPLOYMENT_DIR }}/data-api.yml"

--- a/stanford/playbooks/insights.yml
+++ b/stanford/playbooks/insights.yml
@@ -1,6 +1,6 @@
 - name: Deploy Analytics Insights
   hosts: ~tag_Name_{{ machine }}_{{ env }}
-  sudo: True
+  become: True
   gather_facts: True
   vars_files:
     - "{{ COMMON_DEPLOYMENT_DIR }}/insights.yml"

--- a/stanford/playbooks/kibana.yml
+++ b/stanford/playbooks/kibana.yml
@@ -38,7 +38,7 @@
       healthy_threshold: 2
 - name: Configure instance(s)
   hosts: launched
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     KIBANA_ENABLE_SSL: true

--- a/stanford/playbooks/logstash.yml
+++ b/stanford/playbooks/logstash.yml
@@ -30,7 +30,7 @@
       healthy_threshold: 10
 - name: Configure instance(s)
   hosts: launched
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     # take in number of mega bytes, will scale it properly 

--- a/stanford/playbooks/maintenance.yml
+++ b/stanford/playbooks/maintenance.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: ~tag_Name_{{ machine }}_{{ env }}
-  sudo: True
+  become: True
   vars_files:
     - "{{ COMMON_DEPLOYMENT_DIR }}/common.yaml"
     - "{{ COMMON_DEPLOYMENT_DIR }}/edxapp-common.yaml"


### PR DESCRIPTION
It has been deprecated and subsequently removed from future ansible
releases, in favor of the `become` keyword.