### PR TITLE
Fix cluster role's optional include

### DIFF
--- a/stanford/playbooks/cluster.yml
+++ b/stanford/playbooks/cluster.yml
@@ -4,6 +4,7 @@
   connection: local
   gather_facts: False
   tasks:
+    - include_vars: "{{ COMMON_DEPLOYMENT_DIR }}/common.yaml"
     - include_vars: "{{ item }}"
       with_first_found:
         - files:
@@ -12,8 +13,6 @@
 - hosts: localhost
   connection: local
   gather_facts: False
-  vars_files:
-    - "{{ COMMON_DEPLOYMENT_DIR }}/common.yaml"
   roles:
     - role: cluster
 - name: Bootstrap instance(s)

--- a/stanford/playbooks/cluster.yml
+++ b/stanford/playbooks/cluster.yml
@@ -3,14 +3,17 @@
 - hosts: localhost
   connection: local
   gather_facts: False
-  vars_files:
-    - "{{ COMMON_DEPLOYMENT_DIR }}/common.yaml"
   tasks:
     - include_vars: "{{ item }}"
       with_first_found:
         - files:
           - "{{ COMMON_DEPLOYMENT_DIR }}/{{ CLUSTER_NAME }}.yml"
           skip: true
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars_files:
+    - "{{ COMMON_DEPLOYMENT_DIR }}/common.yaml"
   roles:
     - role: cluster
 - name: Bootstrap instance(s)


### PR DESCRIPTION
It looks like this hasn't actually been working,
because the `tasks` section isn't executed prior to the `roles`.

By just splitting this out into two separate plays,
we can ensure they are executed in the proper order.
And since the former play is simply an include,
it doesn't rely on any side-effects of the latter.