### PR TITLE
Fix insights play

### DIFF
--- a/stanford/playbooks/insights.yml
+++ b/stanford/playbooks/insights.yml
@@ -25,7 +25,8 @@
     - role: nginx
       nginx_sites:
         - insights
-    - insights
+    - role: insights
+      COMMON_GIT_PATH: 'Stanford-Online'
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
   tasks:

--- a/stanford/stage/insights1.yml
+++ b/stanford/stage/insights1.yml
@@ -2,5 +2,6 @@
 ---
 - include: ../playbooks/insights.yml
   vars:
+    CLUSTER_INSTANCE_TYPE: t2.medium
     CLUSTER_NUMBER: 1
     COMMON_DEPLOYMENT: stage


### PR DESCRIPTION
Required for Insights play to run.

t2.micro doesn't have enough memory for the install.