### PR TITLE
Fix expired key in devstack

### DIFF
--- a/stanford/AUTHORS
+++ b/stanford/AUTHORS
@@ -1,0 +1,1 @@
+Tony Kim <tkim6@stanford.edu>

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -95,6 +95,9 @@ cd /edx/app/edx_ansible/edx_ansible/playbooks
 EXTRA_VARS="#{extra_vars_lines}"
 CONFIG_VER="#{ENV['CONFIGURATION_VERSION'] || openedx_release || 'master'}"
 
+apt-key del 69464050
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 69464050
+
 ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
 ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS
 


### PR DESCRIPTION
The devstack still included a reference to an expired edx key.
Until it was removed, any attempts to run `apt-get update` would fail.
This prevented us from creating a new devstack.