### PR TITLE
Remove reference to ecommerce requirements file that no longer exists.

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -234,7 +234,6 @@ ecommerce_log_dir: "{{ COMMON_LOG_DIR }}/{{ ecommerce_service_name }}"
 ecommerce_requirements_base: "{{ ecommerce_code_dir }}/requirements"
 ecommerce_requirements:
   - production.txt
-  - optional.txt
 
 ecommerce_environment:
   DJANGO_SETTINGS_MODULE: "{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}"


### PR DESCRIPTION
The ecommerce playbook installs edx master but that version does not have the requirements/optional.txt file.