### PR TITLE
Open HTTP/S ports for elasticsearch

### DIFF
--- a/stanford/roles/cluster/defaults/main.yml
+++ b/stanford/roles/cluster/defaults/main.yml
@@ -191,6 +191,14 @@ CLUSTER_SECURITY_GROUP_RULES:
       from_port: 22
       to_port: 22
       cidr_ip: "{{ DEPLOYMENT_CIDR }}"
+    - proto: tcp
+      from_port: 80
+      to_port: 80
+      cidr_ip: "{{ DEPLOYMENT_CIDR }}"
+    - proto: tcp
+      from_port: 443
+      to_port: 443
+      cidr_ip: "{{ DEPLOYMENT_CIDR }}"
   forum:
     - proto: tcp
       from_port: 22


### PR DESCRIPTION
for using the AWS Elasticsearch Service.
Using HTTP also allows us to use internal DNS names w/out worrying about
SSL cert issues on the default AWS hostname.