### PR TITLE
Add default for MAX_ENROLLEES_FOR_METRICS_USING_DB

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -123,6 +123,7 @@ EDXAPP_LANGUAGES:
   - ['ru', 'Русский']
   - ['vi', 'Tiếng Việt']
   - ['zh-cn', '中文 (简体)']
+EDXAPP_MAX_ENROLLEES_FOR_METRICS_USING_DB: 100
 EDXAPP_PASSWORD_COMPLEXITY:
   UPPER: 1
   LOWER: 1


### PR DESCRIPTION
else creation of the JSON fails for non-SUclass deployments.