### PR TITLE
Disable SECURITY_UPGRADE_ON_ANSIBLE in devstack

### DIFF
--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -18,7 +18,7 @@
     ECOMMERCE_DJANGO_SETTINGS_MODULE: "ecommerce.settings.devstack"
     # When provisioning your devstack, we apply security updates
     COMMON_SECURITY_UPDATES: true
-    SECURITY_UPGRADE_ON_ANSIBLE: true
+    SECURITY_UPGRADE_ON_ANSIBLE: false
     MONGO_AUTH: false
     DISCOVERY_URL_ROOT: 'http://localhost:{{ DISCOVERY_NGINX_PORT }}'
     DISCOVERY_NGINX_PORT: 80  # TEMP: else oauth_client_setup breaks

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -102,8 +102,8 @@ CONFIG_VER="#{ENV['CONFIGURATION_VERSION'] || openedx_release || 'master'}"
 apt-key del 69464050
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 69464050
 
-ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
-ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS
+ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS -e SECURITY_UPGRADE_ON_ANSIBLE=false
+ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS -e SECURITY_UPGRADE_ON_ANSIBLE=false
 
 SCRIPT
 


### PR DESCRIPTION
since a recent elasticsearch causes provisioning to fail [1].
The vagrant-based devstack is deprecated and will not be used following
our upgrade to hawthorn.

- [1] Package elasticsearch has conffile prompt and needs to be upgraded
      manually