### PR TITLE
Increase grade report concurrency on worker boxes

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -704,7 +704,7 @@ EDXAPP_CELERY_WORKERS:
     monitor: True
   - queue: high_mem
     service_variant: lms
-    concurrency: 1
+    concurrency: 2
     monitor: False
     max_tasks_per_child: 1
     use_codejail_proxy: 1


### PR DESCRIPTION
since we've opted to run fewer, larger instances.

Hopefully, this will allow for more utlization of our resources and
prevent cases where the queue becomes too backed up.