### PR TITLE
Dump deployment logs

### DIFF
--- a/stanford/bin/dump-logs
+++ b/stanford/bin/dump-logs
@@ -26,12 +26,11 @@ for deployment in ${deployments}; do
             fi
         done
     done
-    cd "${destination_root}"
-    find "${deployment}/" -name '*.gz' -print0 | xargs -0 gunzip --keep --force
-    archive_file="${deployment}-logs-$(date +%Y-%m-%d-%s).tar.gz"
+    find "${destination_root}/${deployment}/" -name '*.gz' -print0 | xargs -0 gunzip --keep --force
+    archive_file="${destination_root}/${deployment}-logs-$(date +%Y-%m-%d-%s).tar.gz"
     tar czvf "${archive_file}" \
         --exclude='*.gz' \
         --options='compression-level=9' \
-        "${deployment}/" \
+        "${destination_root}/${deployment}/" \
     ;
 done

--- a/stanford/bin/dump-logs
+++ b/stanford/bin/dump-logs
@@ -1,0 +1,37 @@
+#!/bin/sh
+rsync_sudo() {
+    rsync --rsync-path='sudo rsync' -avh --progress ${@}
+}
+rsync_logs() {
+    machine=${1}
+    destination=${2}
+    shift; shift;
+    rsync_sudo ${@} "${machine}:/var/log/" "${destination}"
+    rsync_sudo ${@} "${machine}:/edx/var/log/" "${destination}/edx"
+}
+destination_root=/edx/var/log
+deployments="cme"
+clusters="analytics-api build certs coursegraph deploy director edxapp esforum forum insights jump maintenance nat notifier rabbitmq scheduler worker xqueue"
+for deployment in ${deployments}; do
+    for cluster in ${clusters}; do
+        for number in {0..4}; do
+            box="${cluster}${number}"
+            machine=${box}.${deployment}.vpc
+            if ssh -q -o ConnectTimeout=1 "${machine}" 'exit' 2>/dev/null; then
+                echo "Dumping logs from: ${machine}"
+                destination_box=${destination_root}/${deployment}/${box}
+                mkdir -p "${destination_box}"
+                rsync_logs "${machine}" "${destination_box}" --delete
+                echo; echo
+            fi
+        done
+    done
+    cd "${destination_root}"
+    find "${deployment}/" -name '*.gz' -print0 | xargs -0 gunzip --keep --force
+    archive_file="${deployment}-logs-$(date +%Y-%m-%d-%s).tar.gz"
+    tar czvf "${archive_file}" \
+        --exclude='*.gz' \
+        --options='compression-level=9' \
+        "${deployment}/" \
+    ;
+done

--- a/stanford/bin/dump-logs
+++ b/stanford/bin/dump-logs
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Usage: dump-logs [/edx/var|<output_directory>]
+# ENV VARS:
+# - DUMP_LOGS_DEPLOYMENTS: a list of deployments to dump
+# - DUMP_LOGS_CLUSTERS: a list of clusters to dump
 rsync_sudo() {
     rsync --rsync-path='sudo rsync' -avh --progress ${@}
 }
@@ -9,9 +13,10 @@ rsync_logs() {
     rsync_sudo ${@} "${machine}:/var/log/" "${destination}"
     rsync_sudo ${@} "${machine}:/edx/var/log/" "${destination}/edx"
 }
-destination_root=/edx/var/log
-deployments="cme"
-clusters="analytics-api build certs coursegraph deploy director edxapp esforum forum insights jump maintenance nat notifier rabbitmq scheduler worker xqueue"
+destination_root_base=${1:-/edx/var}
+destination_root=${destination_root_base}/log
+deployments="${DUMP_LOGS_DEPLOYMENTS:-cme}"
+clusters="${DUMP_LOGS_CLUSTERS:-analytics-api build certs coursegraph deploy director edxapp esforum forum insights jump maintenance nat notifier rabbitmq scheduler worker xqueue}"
 for deployment in ${deployments}; do
     for cluster in ${clusters}; do
         for number in {0..4}; do
@@ -27,10 +32,11 @@ for deployment in ${deployments}; do
         done
     done
     find "${destination_root}/${deployment}/" -name '*.gz' -print0 | xargs -0 gunzip --keep --force
-    archive_file="${destination_root}/${deployment}-logs-$(date +%Y-%m-%d-%s).tar.gz"
+    archive_file="${destination_root_base}/${deployment}-log-$(date +%Y-%m-%d-%s).tar.gz"
     tar czvf "${archive_file}" \
+        -C "${destination_root_base}" \
         --exclude='*.gz' \
         --options='compression-level=9' \
-        "${destination_root}/${deployment}/" \
+        "log/${deployment}/" \
     ;
 done


### PR DESCRIPTION
This can be used to crawl and dump all logs (edx and system) and archive them into a single tarball.

This will initially be used for CME, then elsewhere.